### PR TITLE
Fix Demo Links: Update to Working Vercel Deployment

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -563,7 +563,7 @@ graph TD
 ---
 
 # Stack Evaluator in Action
-## https://stack.organizedai.vip
+## https://web-fpi95p595-jordaaans-projects.vercel.app/
 
 <div class="grid grid-cols-2 gap-8 max-w-5xl mx-auto">
 
@@ -604,7 +604,7 @@ graph TD
 </div>
 
 <div class="text-center pt-4">
-<a href="https://stack.organizedai.vip" class="text-blue-300 text-lg">→ Try Live Demo</a>
+<a href="https://web-fpi95p595-jordaaans-projects.vercel.app/" class="text-blue-300 text-lg">→ Try Live Demo</a>
 </div>
 
 </div>
@@ -893,7 +893,7 @@ Total Budget: 40 sessions, 4.7M tokens ≈ $75
 ### **1. Evaluate** ⚡
 <div class="text-sm space-y-2">
 
-Visit **stack.organizedai.vip**
+Visit **web-fpi95p595-jordaaans-projects.vercel.app**
 
 Answer 5 questions  
 Get personalized stack  
@@ -941,7 +941,7 @@ Keep improving
 
 ### **Community Links**
 <div class="text-sm">
-🌐 **stack.organizedai.vip** • 📚 **github.com/Organized-AI/starter-stacks** • 💬 **lu.ma/Organizedai**
+🌐 **web-fpi95p595-jordaaans-projects.vercel.app** • 📚 **github.com/Organized-AI/starter-stacks** • 💬 **lu.ma/Organizedai**
 </div>
 
 </div>
@@ -996,7 +996,7 @@ Keep improving
 ### **Ready to join the Speed Revolution?**
 
 <div class="text-lg mt-4">
-<a href="https://stack.organizedai.vip" class="text-blue-300">→ Start with the Stack Evaluator</a>
+<a href="https://web-fpi95p595-jordaaans-projects.vercel.app/" class="text-blue-300">→ Start with the Stack Evaluator</a>
 </div>
 
 </div>


### PR DESCRIPTION
🔗 **DEMO LINKS FIXED**: All evaluator links now point to the working Vercel deployment!

## ✅ **Problem Solved**
- Fixed the broken 'Try Live Demo' link on slide 17
- Updated all references to stack.organizedai.vip → working Vercel deployment
- Ensures live demos work during presentations

## 📍 **Links Updated**

### **Slide 17 - Stack Evaluator Section**
- **Slide heading**: Now shows working URL  
- **Try Live Demo button**: → https://web-fpi95p595-jordaaans-projects.vercel.app/

### **Other References Updated for Consistency**
- **Implementation slide**: 'Visit' instruction → working endpoint
- **Community links**: Updated in footer section
- **Final call-to-action**: 'Start with Stack Evaluator' → working deployment

## 🎪 **Presentation Ready**
- **Live demos work**: Audience can actually try the evaluator
- **Professional appearance**: No broken links during presentations
- **Interactive engagement**: Real working tool integration
- **Consistent messaging**: All references point to same working endpoint

## 🚀 **Impact**
- **Presenters**: Can confidently demo live functionality
- **Audiences**: Can immediately try the tool during or after presentations
- **Engagement**: Working links increase audience interaction and follow-through
- **Credibility**: Professional presentation with functional demonstrations

Ready to deploy working demo links! 🎉